### PR TITLE
Consistent exception types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 lint:
-	isort --project popmon --multi-line=3 --trailing-comma --force-grid-wrap=0 --use-parentheses --line-width=88
+	isort --project popmon --multi-line=3 --trailing-comma --force-grid-wrap=0 --use-parentheses --line-width=88 -y
 	black .

--- a/popmon/alerting/compute_tl_bounds.py
+++ b/popmon/alerting/compute_tl_bounds.py
@@ -149,7 +149,7 @@ class ComputeTLBounds(Module):
 
         # check inputs
         if not isinstance(self.traffic_light_func, collections.Callable):
-            raise AssertionError("supplied function must be callable object")
+            raise TypeError("supplied function must be callable object")
 
     def _set_traffic_lights(self, feature, cols, pattern, rule_name):
         process_cols = fnmatch.filter(cols, pattern)

--- a/popmon/analysis/apply_func.py
+++ b/popmon/analysis/apply_func.py
@@ -87,10 +87,10 @@ class ApplyFunc(Module):
         """
         # check inputs
         if not isinstance(func, collections.Callable):
-            raise AssertionError("functions in ApplyFunc must be callable objects")
-        if not isinstance(suffix, (str, type(None))) or not isinstance(
-            prefix, (str, type(None))
-        ):
+            raise TypeError("functions in ApplyFunc must be callable objects")
+        if suffix is not None and not isinstance(suffix, str):
+            raise TypeError("prefix, and suffix in ApplyFunc must be strings or None.")
+        if prefix is not None and not isinstance(prefix, str):
             raise TypeError("prefix, and suffix in ApplyFunc must be strings or None.")
         if not isinstance(metrics, list) or not isinstance(features, list):
             raise TypeError("metrics and features must be lists of strings.")

--- a/popmon/analysis/comparison/hist_comparer.py
+++ b/popmon/analysis/comparison/hist_comparer.py
@@ -389,7 +389,7 @@ class RollingNormHistComparer(NormHistComparer):
         :param str hist_col: column/key in input df/dict that contains the histogram. default is 'histogram'
         """
         if window < 2:
-            raise AssertionError("Need window size of 2 or greater.")
+            raise ValueError("Need window size of 2 or greater.")
         kws = {"window": window, "shift": shift, "entire": True}
         super().__init__(
             roll_norm_hist_mean_cov, read_key, store_key, read_key, hist_col, **kws

--- a/popmon/analysis/hist_numpy.py
+++ b/popmon/analysis/hist_numpy.py
@@ -129,7 +129,7 @@ def get_consistent_numpy_2dgrids(hc_list=[], get_bin_labels=False):
     """
     # --- basic checks
     if len(hc_list) == 0:
-        raise RuntimeError("Input histogram list has zero length.")
+        raise ValueError("Input histogram list has zero length.")
     assert_similar_hists(hc_list)
 
     hist_list = [
@@ -139,7 +139,7 @@ def get_consistent_numpy_2dgrids(hc_list=[], get_bin_labels=False):
     ykeys = set()
     for hist in hist_list:
         if hist.n_dim < 2:
-            raise AssertionError(
+            raise ValueError(
                 "Input histogram only has {n} dimensions (<2). Cannot compute 2d-grid.".format(
                     n=hist.n_dim
                 )
@@ -229,7 +229,7 @@ def get_consistent_numpy_entries(hc_list, get_bin_labels=False):
     all_num = all(is_num_arr)
     all_cat = not any(is_num_arr)
     if not (all_num or all_cat):
-        raise AssertionError(
+        raise TypeError(
             "Input histograms are mixture of Bin/SparselyBin and Categorize types.".format(
                 n=hc_list[0].hist.n_dim
             )
@@ -297,7 +297,7 @@ def check_similar_hists(hc_list, check_type=True, assert_type=used_hist_types):
         return True
     for hist in hist_list:
         if not isinstance(hist, assert_type):
-            raise AssertionError(
+            raise TypeError(
                 "Input histogram type {htype} not of {htypes}.".format(
                     htype=type(hist), htypes=assert_type
                 )
@@ -415,7 +415,7 @@ def assert_similar_hists(hc_list, check_type=True, assert_type=used_hist_types):
         hc_list, check_type=check_type, assert_type=assert_type
     )
     if not similar:
-        raise AssertionError("Input histograms are not all similar.")
+        raise ValueError("Input histograms are not all similar.")
 
 
 def check_same_hists(hc1, hc2):

--- a/popmon/hist/filling/histogram_filler_base.py
+++ b/popmon/hist/filling/histogram_filler_base.py
@@ -453,11 +453,11 @@ class HistogramFillerBase(Module):
         :return: datastore
         """
         if not isinstance(self.read_key, str) and len(self.read_key) > 0:
-            raise AssertionError("read_key has not been properly set.")
+            raise ValueError("read_key has not been properly set.")
         if not isinstance(self.store_key, str) and len(self.store_key) > 0:
-            raise AssertionError("store_key has not been properly set.")
+            raise ValueError("store_key has not been properly set.")
         if self.read_key not in datastore:
-            raise RuntimeError("read_key not found in datastore")
+            raise KeyError("read_key not found in datastore")
 
         df = datastore[self.read_key]
         hists = self.get_histograms(df)

--- a/popmon/hist/filling/make_histograms.py
+++ b/popmon/hist/filling/make_histograms.py
@@ -80,15 +80,13 @@ def make_histograms(
     if (not isinstance(time_axis, (str, bool))) or (
         isinstance(time_axis, bool) and not time_axis
     ):
-        raise AssertionError("time_axis needs to be a string, or a bool set to True")
+        raise TypeError("time_axis needs to be a string, or a bool set to True")
     if (
         isinstance(time_axis, str)
         and len(time_axis) > 0
         and time_axis not in df.columns
     ):
-        raise AssertionError(
-            f'time_axis "{time_axis}" not found in columns of dataframe.'
-        )
+        raise ValueError(f'time_axis "{time_axis}" not found in columns of dataframe.')
     if isinstance(time_axis, bool):
         time_axes = get_time_axes(df)
         num = len(time_axes)

--- a/popmon/hist/histogram.py
+++ b/popmon/hist/histogram.py
@@ -139,11 +139,11 @@ def project_split2dhist_on_axis(splitdict, axis="x"):
     :rtype: SortedDict
     """
     if not isinstance(splitdict, dict):
-        raise AssertionError(
+        raise TypeError(
             "splitdict: {wt}, type should be a dictionary.".format(wt=type(splitdict))
         )
     if axis not in ["x", "y"]:
-        raise AssertionError("axis: {axis}, can only be x or y.".format(axis=axis))
+        raise ValueError("axis: {axis}, can only be x or y.".format(axis=axis))
 
     hdict = dict()
 
@@ -172,8 +172,8 @@ class HistogramContainer:
             self.hist = HG_FACTORY.fromJsonString(hist_obj)
         elif isinstance(hist_obj, dict):
             self.hist = HG_FACTORY.fromJson(hist_obj)
-        if isinstance(self.hist, type(None)):
-            raise AssertionError(
+        if self.hist is None:
+            raise ValueError(
                 "Please provide histogram or histogram container as input."
             )
 

--- a/popmon/pipeline/metrics.py
+++ b/popmon/pipeline/metrics.py
@@ -86,12 +86,12 @@ def stability_metrics(
     # perform basic input checks
     reference_types = list(_metrics_pipeline.keys())
     if reference_type not in reference_types:
-        raise AssertionError(f"reference_type should be one of {str(reference_types)}.")
+        raise TypeError(f"reference_type should be one of {str(reference_types)}.")
 
     if not isinstance(hists, dict):
-        raise AssertionError("hists should be a dict of histogrammar histograms.")
+        raise TypeError("hists should be a dict of histogrammar histograms.")
     if reference_type == "external" and not isinstance(reference, dict):
-        raise AssertionError("reference should be a dict of histogrammar histograms.")
+        raise TypeError("reference should be a dict of histogrammar histograms.")
 
     if not isinstance(monitoring_rules, dict):
         monitoring_rules = {
@@ -238,14 +238,12 @@ def df_stability_metrics(
     if not (isinstance(time_axis, str) and len(time_axis) > 0) and not (
         isinstance(time_axis, bool) and time_axis
     ):
-        raise AssertionError("time_axis needs to be a filled string or set to True")
+        raise TypeError("time_axis needs to be a filled string or set to True")
     if isinstance(time_axis, str) and time_axis not in df.columns:
-        raise AssertionError(
-            f'time_axis  "{time_axis}" not found in columns of dataframe.'
-        )
+        raise ValueError(f'time_axis  "{time_axis}" not found in columns of dataframe.')
     if reference is not None and not isinstance(reference, dict):
         if isinstance(time_axis, str) and time_axis not in reference.columns:
-            raise AssertionError(
+            raise ValueError(
                 f'time_axis  "{time_axis}" not found in columns of reference dataframe.'
             )
     if isinstance(time_axis, bool):

--- a/popmon/pipeline/report.py
+++ b/popmon/pipeline/report.py
@@ -102,12 +102,12 @@ def stability_report(
     # perform basic input checks
     reference_types = list(_report_pipeline.keys())
     if reference_type not in reference_types:
-        raise AssertionError(f"reference_type should be one of {str(reference_types)}.")
+        raise TypeError(f"reference_type should be one of {str(reference_types)}.")
 
     if not isinstance(hists, dict):
-        raise AssertionError("hists should be a dict of histogrammar histograms.")
+        raise TypeError("hists should be a dict of histogrammar histograms.")
     if reference_type == "external" and not isinstance(reference, dict):
-        raise AssertionError("reference should be a dict of histogrammar histograms.")
+        raise TypeError("reference should be a dict of histogrammar histograms.")
 
     if not isinstance(monitoring_rules, dict):
         monitoring_rules = {
@@ -276,14 +276,12 @@ def df_stability_report(
     if not (isinstance(time_axis, str) and len(time_axis) > 0) and not (
         isinstance(time_axis, bool) and time_axis
     ):
-        raise AssertionError("time_axis needs to be a filled string or set to True")
+        raise ValueError("time_axis needs to be a filled string or set to True")
     if isinstance(time_axis, str) and time_axis not in df.columns:
-        raise AssertionError(
-            f'time_axis  "{time_axis}" not found in columns of dataframe.'
-        )
+        raise ValueError(f'time_axis  "{time_axis}" not found in columns of dataframe.')
     if reference is not None and not isinstance(reference, dict):
         if isinstance(time_axis, str) and time_axis not in reference.columns:
-            raise AssertionError(
+            raise ValueError(
                 f'time_axis  "{time_axis}" not found in columns of reference dataframe.'
             )
     if isinstance(time_axis, bool):

--- a/popmon/visualization/utils.py
+++ b/popmon/visualization/utils.py
@@ -5,7 +5,6 @@ from io import BytesIO
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-
 import pybase64
 
 NUM_NS_DAY = 24 * 3600 * int(1e9)

--- a/popmon/visualization/utils.py
+++ b/popmon/visualization/utils.py
@@ -5,6 +5,7 @@ from io import BytesIO
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+
 import pybase64
 
 NUM_NS_DAY = 24 * 3600 * int(1e9)
@@ -259,7 +260,7 @@ def plot_overlay_1d_histogram_b64(
         hist_names = [f"hist{i}" for i in range(len(hists))]
     if hist_names:
         if len(hists) != len(hist_names):
-            raise AssertionError("length of hist and hist_names are different")
+            raise ValueError("length of hist and hist_names are different")
 
     plt.figure(figsize=(9, 7))
 

--- a/tests/popmon/analysis/test_hist_numpy.py
+++ b/tests/popmon/analysis/test_hist_numpy.py
@@ -246,7 +246,7 @@ def test_get_consistent_numpy_2dgrids():
     args = [""]
     try:
         get_consistent_numpy_2dgrids([hc0, hc0])
-    except AssertionError as e:
+    except ValueError as e:
         args = e.args
 
     grid2d_list = get_consistent_numpy_2dgrids([hc1, hc2])
@@ -478,17 +478,17 @@ def test_assert_similar_hists():
 
     try:
         assert_similar_hists([hc0, hc1])
-    except AssertionError as e:
+    except ValueError as e:
         args01 = e.args
 
     try:
         assert_similar_hists([hc2, hc3])
-    except AssertionError as e:
+    except ValueError as e:
         args23 = e.args
 
     try:
         assert_similar_hists([hc4, hc5])
-    except AssertionError as e:
+    except ValueError as e:
         args45 = e.args
 
     assert args01[0] == "Input histograms are not all similar."


### PR DESCRIPTION
Exception types are associated with the kind of event in which they are raised. For example the "AssertionError" is raised when an assert statement fails. Assert statements are generally used for debugging purposes, not as a mechanism for handling run-time errors. One thing to note is that asserts can be turned off globally in the Python interpreter for optimization. 

The current codebase uses exception types as AssertionError and RuntimeError interchangeably. This PR proposes to use exception types that are more consistent with the type of error, following the descriptions at https://docs.python.org/3/library/exceptions.html#concrete-exceptions.