### PR TITLE
Fix makefile third party modules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # check using isort and black
-        make lint_check
+        make lint check=1
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,13 +27,10 @@ jobs:
         pip install -r requirements-test.txt
     - name: Lint with flake8 and black
       run: |
-        pip install flake8 black isort
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # check using isort
-        isort --check-only --project popmon --multi-line=3 --trailing-comma --force-grid-wrap=0 --use-parentheses --line-width=88
-        # check using black
-        black --check .
+        # check using isort and black
+        make lint_check
     - name: Test with pytest
       run: |
         pip install pytest

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
 lint:
 	isort --project popmon --thirdparty histogrammar --thirdparty pybase64 --multi-line=3 --trailing-comma --force-grid-wrap=0 --use-parentheses --line-width=88 -y
-	black . 
+	black .
+
+lint_check:
+	isort --check-only --project popmon --thirdparty histogrammar --thirdparty pybase64 --multi-line=3 --trailing-comma --force-grid-wrap=0 --use-parentheses --line-width=88 -y
+	black --check .

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-lint:
-	isort --project popmon --thirdparty histogrammar --thirdparty pybase64 --multi-line=3 --trailing-comma --force-grid-wrap=0 --use-parentheses --line-width=88 -y
-	black .
+ifeq ($(check),1)
+	ISORT_ARG= --check-only
+	BLACK_ARG= --check
+else
+	ISORT_ARG=
+	BLACK_ARG=
+endif
 
-lint_check:
-	isort --check-only --project popmon --thirdparty histogrammar --thirdparty pybase64 --multi-line=3 --trailing-comma --force-grid-wrap=0 --use-parentheses --line-width=88 -y
-	black --check .
+lint:
+	isort $(ISORT_ARG) --project popmon --thirdparty histogrammar --thirdparty pybase64 --multi-line=3 --trailing-comma --force-grid-wrap=0 --use-parentheses --line-width=88 -y
+	black $(BLACK_ARG) .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
 lint:
-	isort --project popmon --multi-line=3 --trailing-comma --force-grid-wrap=0 --use-parentheses --line-width=88 -y
-	black .
-
-install:
-	pip install -e .
+	isort --project popmon --thirdparty histogrammar --thirdparty pybase64 --multi-line=3 --trailing-comma --force-grid-wrap=0 --use-parentheses --line-width=88 -y
+	black . 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,3 +5,4 @@ nbconvert>=5.3.1
 jupyter_client>=5.2.3
 ipykernel>=5.1.3
 black>=19.10b0
+isort>=4.3.21


### PR DESCRIPTION
As a developer I'd like linting to format consistently across platforms. The `histogrammar` and `pybase64` modules are sometimes picked up by isort as part of the `popmon` module (for `histogrammar` because we patch it, unsure why for `pybase64`). This PR explicitly states that both modules are third party modules, leading to consistent formatting.