### PR TITLE
Ignore .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,4 +142,4 @@ cython_debug/
 docs/build
 
 .vscode
-.idea
+.idea/


### PR DESCRIPTION
The .gitignore syntax requires a slash at the end of directory names (https://git-scm.com/docs/gitignore#_examples)