### PR TITLE
Install popmon at the beginning of notebooks

### DIFF
--- a/popmon/notebooks/popmon_tutorial_advanced.ipynb
+++ b/popmon/notebooks/popmon_tutorial_advanced.ipynb
@@ -14,18 +14,32 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from IPython.core.display import display, HTML\n",
     "display(HTML(\"<style>.container { width:80% !important; }</style>\"))\n",
     "display(HTML(\"<style>div.output_scroll { height: 44em; }</style>\"))"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# install popmon (if not installed yet)\n",
+    "import sys\n",
+    "!{sys.executable} -m pip install popmon"
+   ]
   },
   {
    "cell_type": "code",
@@ -400,7 +414,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   },
   "nteract": {
    "version": "0.15.0"
@@ -408,10 +422,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },

--- a/popmon/notebooks/popmon_tutorial_basic.ipynb
+++ b/popmon/notebooks/popmon_tutorial_basic.ipynb
@@ -14,6 +14,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# (optional) Adjust the jupyter notebook style for easier navigation of the reports\n",
@@ -22,13 +31,7 @@
     "display(HTML(\"<style>.container { width:80% !important; }</style>\"))\n",
     "# Cells are higher by default\n",
     "display(HTML(\"<style>div.output_scroll { height: 44em; }</style>\"))"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -40,9 +43,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# install popmon (if not installed yet)\n",
+    "import sys\n",
+    "!{sys.executable} -m pip install popmon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -93,9 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# generate report based on histograms\n",
@@ -177,18 +187,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   },
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/popmon/notebooks/popmon_tutorial_incremental_data.ipynb
+++ b/popmon/notebooks/popmon_tutorial_incremental_data.ipynb
@@ -36,9 +36,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# install popmon (if not installed yet)\n",
+    "import sys\n",
+    "!{sys.executable} -m pip install popmon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -432,18 +441,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   },
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This provides a more seamless experience when opening notebooks in e.g. `Google Colab` without needing to explicitly add `!pip install popmon` code cell in the notebook (since `popmon` is not installed in `Colab` by default like `pandas` or `numpy`).