### PR TITLE
Fix automated PyPi deployment

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Make distribution
       run: |
-        pip install twine
+        pip install twine wheel
         python setup.py sdist bdist_wheel
         twine check dist/*
     - name: Publish a Python distribution to PyPI


### PR DESCRIPTION
The automated PyPi deployment Github Action is broken:
```
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: invalid command 'bdist_wheel'
```

This PR resolves this by installing the `wheel` dependency.