### PR TITLE
Consistent column case (fix)

### DIFF
--- a/popmon/visualization/templates/assets/js/custom-script.js
+++ b/popmon/visualization/templates/assets/js/custom-script.js
@@ -7,7 +7,7 @@ $(document).on("click", "button.dropdown-item", function() {
     obj = $(this)
     obj.closest("section").find("div.section_feature").hide()
     obj.closest("section").find("div[data-section-feature='" + obj.attr("data-feature") + "']").show()
-    obj.parent().siblings("button").text("Feature: " + obj.text()())
+    obj.parent().siblings("button").text("Feature: " + obj.text())
 });
 // making navigation work: after clicking a nav link scrolling to the corresponding section's position
 $(document).on("click", "a.nav-link", function(e) {


### PR DESCRIPTION
JavaScript code is not functioning properly since `()` were left when removing the `.toLowerCase` function in the previous PR (as a result: feature/column name was not being updated accordingly when selecting a different option from the dropdown menu).