### PR TITLE
Upgrade to isort 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ docs/build
 
 .vscode
 .idea/
+
+# Developer's playground
+/playground/

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,12 @@
 ifeq ($(check),1)
-	ISORT_ARG= --check-only
-	BLACK_ARG= --check
+	CHECK_ARG= --check
 else
-	ISORT_ARG=
-	BLACK_ARG=
+	CHECK_ARG=
 endif
 
 lint:
-	isort $(ISORT_ARG) --project popmon --thirdparty histogrammar --thirdparty pybase64 --multi-line=3 --trailing-comma --force-grid-wrap=0 --use-parentheses --line-width=88 -y
-	black $(BLACK_ARG) .
+	isort $(CHECK_ARG) --profile black --project popmon --thirdparty histogrammar --thirdparty pybase64 .
+	black $(CHECK_ARG) .
 
 install:
 	pip install -e .

--- a/make.bat
+++ b/make.bat
@@ -4,14 +4,12 @@ setlocal enabledelayedexpansion
 
 IF "%1%" == "lint" (
 	IF "%2%" == "check" (
-		SET ISORT_ARG= --check-only
-		SET BLACK_ARG= --check
+		SET CHECK_ARG= --check
 	) ELSE (
-		set ISORT_ARG=
-		set BLACK_ARG=
+		set CHECK_ARG=
 	)
-	isort !ISORT_ARG! --project popmon --thirdparty histogrammar --thirdparty pybase64 --multi-line=3 --trailing-comma --force-grid-wrap=0 --use-parentheses --line-width=88 -y
-	black !BLACK_ARG! .
+	isort !CHECK_ARG! --profile black --project popmon --thirdparty histogrammar --thirdparty pybase64 .
+	black !CHECK_ARG! .
 	GOTO end
 )
 

--- a/popmon/analysis/profiling/hist_profiler.py
+++ b/popmon/analysis/profiling/hist_profiler.py
@@ -22,7 +22,7 @@ import numpy as np
 import pandas as pd
 from phik import phik
 
-import popmon.stats.numpy as pm_np
+from popmon.stats import numpy as pm_np
 
 from ...analysis.hist_numpy import get_2dgrid
 from ...base import Module

--- a/popmon/hist/filling/spark_histogrammar.py
+++ b/popmon/hist/filling/spark_histogrammar.py
@@ -15,7 +15,8 @@ from ...hist.filling.histogram_filler_base import HistogramFillerBase
 
 try:
     from pyspark.sql import DataFrame
-    from pyspark.sql.functions import col as sparkcol, approxCountDistinct
+    from pyspark.sql.functions import approxCountDistinct
+    from pyspark.sql.functions import col as sparkcol
 except (ModuleNotFoundError, AttributeError):
     pass
 

--- a/popmon/visualization/backend.py
+++ b/popmon/visualization/backend.py
@@ -148,7 +148,7 @@ def in_ipynb():
     :rtype: bool
     """
     try:
-        import IPython.core.getipython as gip
+        from IPython.core import getipython as gip
 
         cfg = gip.get_ipython().config
         return True if "IPKernelApp" in cfg.keys() else False

--- a/popmon/visualization/utils.py
+++ b/popmon/visualization/utils.py
@@ -22,11 +22,11 @@ import logging
 import math
 from io import BytesIO
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pybase64
 from ing_theme_matplotlib import mpl_style
+from matplotlib import pyplot as plt
 
 NUM_NS_DAY = 24 * 3600 * int(1e9)
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,7 @@
 flake8>=3.7.8
 pytest>=4.0.2
-pytest-pylint>=0.13.0
 nbconvert>=5.3.1
 jupyter_client>=5.2.3
 ipykernel>=5.1.3
 black>=19.10b0
-isort==4.3.21
+isort>=5.0.7


### PR DESCRIPTION
Previously we pinned the isort version to ensure that isort's new release wouldn't break our pipelines. This PR changes popmon to be compatible with isort 5. This new major release results in a handful of changes in import formatting. Moreover, the CLI has improved, simplifying our makefiles.

Note that there is an issue with `isort==5.0.7` if you're a Windows user when running `make lint check=1`.
See https://github.com/timothycrosley/isort/issues/1277.