### PR TITLE
Support spark date type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,11 @@ jobs:
         python-version: 3.6
     - name: Install Spark
       env:
-        BUILD_DIR: ${{ github.workspace }}
+        BUILD_DIR: ${{ github.home }}
         JAVA_HOME: "/usr/lib/jvm/java-8-openjdk-amd64"
         SPARK_VERSION: "2.4.7"
         HADOOP_VERSION: "2.7"
-        SPARK_HOME: ${{ github.workspace }}/spark/
+        SPARK_HOME: ${{ github.home }}/spark/
       run: |
         sudo apt-get -y install openjdk-8-jdk
         curl https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz --output ${BUILD_DIR}/spark.tgz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         sudo apt-get -y install openjdk-8-jdk
         curl https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz --output ${BUILD_DIR}/spark.tgz
-        tar -xvzf ${BUILD_DIR}/spark.tgz && mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} spark
+        tar -xvzf ${BUILD_DIR}/spark.tgz && mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} ${SPARK_HOME}
         pip install pytest-spark>=0.6.0 pyarrow>=0.8.0 pyspark==2.4.7
     - name: Install dependencies
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,18 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.6
+    - name: Install Spark
+      env:
+        BUILD_DIR: ${{ github.workspace }}
+        JAVA_HOME: "/usr/lib/jvm/java-8-openjdk-amd64"
+        SPARK_VERSION: "2.4.7"
+        HADOOP_VERSION: "2.7"
+        SPARK_HOME: ${{ github.workspace }}/spark/
+      run: |
+        sudo apt-get -y install openjdk-8-jdk
+        curl https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz --output ${BUILD_DIR}/spark.tgz
+        tar -xvzf ${BUILD_DIR}/spark.tgz && mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} spark
+        pip install pytest-spark>=2.4.7 pyarrow>=0.8.0
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -33,7 +45,8 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest
-        pytest
+        pytest -m "not spark"
+        pytest -m spark
 
   examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,11 @@ jobs:
         python-version: 3.6
     - name: Install Spark
       env:
-        BUILD_DIR: ${{ github.workspace }}
+        BUILD_DIR: "/home/runner/work/" #${{ github.workspace }}
         JAVA_HOME: "/usr/lib/jvm/java-8-openjdk-amd64"
         SPARK_VERSION: "2.4.7"
         HADOOP_VERSION: "2.7"
-        SPARK_HOME: ${{ github.workspace }}/spark/
+        SPARK_HOME: "/home/runner/work/spark/" #${{ github.workspace }}/spark/
       run: |
         sudo apt-get -y install openjdk-8-jdk
         curl https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz --output ${BUILD_DIR}/spark.tgz
@@ -36,12 +36,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .
         pip install -r requirements-test.txt
-    - name: Lint with flake8 and black
+    - name: Lint with pre-commit
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # check using isort and black
-        # make lint check=1
+        make lint
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,11 @@ jobs:
         python-version: 3.6
     - name: Install Spark
       env:
-        BUILD_DIR: ${{ github.home }}
+        BUILD_DIR: ${{ github.workspace }}/../
         JAVA_HOME: "/usr/lib/jvm/java-8-openjdk-amd64"
         SPARK_VERSION: "2.4.7"
         HADOOP_VERSION: "2.7"
-        SPARK_HOME: ${{ github.home }}/spark/
+        SPARK_HOME: ${{ github.workspace }}/../spark/
       run: |
         sudo apt-get -y install openjdk-8-jdk
         curl https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz --output ${BUILD_DIR}/spark.tgz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,11 @@ jobs:
         python-version: 3.6
     - name: Install Spark
       env:
-        BUILD_DIR: ${{ github.workspace }}/../
+        BUILD_DIR: ${{ github.workspace }}/../../
         JAVA_HOME: "/usr/lib/jvm/java-8-openjdk-amd64"
         SPARK_VERSION: "2.4.7"
         HADOOP_VERSION: "2.7"
-        SPARK_HOME: ${{ github.workspace }}/../spark/
+        SPARK_HOME: ${{ github.workspace }}/../../spark/
       run: |
         sudo apt-get -y install openjdk-8-jdk
         curl https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz --output ${BUILD_DIR}/spark.tgz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,17 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.6
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+        pip install -r requirements-test.txt
+    - name: Lint with pre-commit
+      run: |
+        make lint
+    - name: Test with pytest
+      run: |
+        pytest -m "not spark"
     - name: Install Spark
       env:
         BUILD_DIR: "/home/runner/work/" #${{ github.workspace }}
@@ -31,18 +42,8 @@ jobs:
         curl https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz --output ${BUILD_DIR}/spark.tgz
         tar -xvzf ${BUILD_DIR}/spark.tgz && mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} ${SPARK_HOME}
         pip install pytest-spark>=0.6.0 pyarrow>=0.8.0 pyspark==2.4.7
-    - name: Install dependencies
+    - name: Test with pytest (spark-specific)
       run: |
-        python -m pip install --upgrade pip
-        pip install -e .
-        pip install -r requirements-test.txt
-    - name: Lint with pre-commit
-      run: |
-        make lint
-    - name: Test with pytest
-      run: |
-        pip install pytest
-        pytest -m "not spark"
         pytest -m spark
 
   examples:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,11 @@ jobs:
         python-version: 3.6
     - name: Install Spark
       env:
-        BUILD_DIR: ${{ github.workspace }}/../../
+        BUILD_DIR: ${{ github.workspace }}
         JAVA_HOME: "/usr/lib/jvm/java-8-openjdk-amd64"
         SPARK_VERSION: "2.4.7"
         HADOOP_VERSION: "2.7"
-        SPARK_HOME: ${{ github.workspace }}/../../spark/
+        SPARK_HOME: ${{ github.workspace }}/spark/
       run: |
         sudo apt-get -y install openjdk-8-jdk
         curl https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz --output ${BUILD_DIR}/spark.tgz
@@ -41,7 +41,7 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # check using isort and black
-        make lint check=1
+        # make lint check=1
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         sudo apt-get -y install openjdk-8-jdk
         curl https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz --output ${BUILD_DIR}/spark.tgz
         tar -xvzf ${BUILD_DIR}/spark.tgz && mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} spark
-        pip install pytest-spark>=2.4.7 pyarrow>=0.8.0
+        pip install pytest-spark>=0.6.0 pyarrow>=0.8.0 pyspark==2.4.7
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
     rev: 20.8b1
     hooks:
     - id: black
-      language_version: python3.6
 -   repo: https://github.com/pycqa/isort
     rev: 5.7.0
     hooks:
@@ -15,3 +14,8 @@ repos:
     hooks:
     -   id: flake8
         args: [ "--select=E9,F63,F7,F82"]
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.7.4
+    hooks:
+    -   id: pyupgrade
+        args: ['--py36-plus','--exit-zero-even-if-changed']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 20.8b1
     hooks:
     - id: black
-      language_version: python3.8
+      language_version: python3.6
 -   repo: https://github.com/pycqa/isort
     rev: 5.7.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+    - id: black
+      language_version: python3.8
+-   repo: https://github.com/pycqa/isort
+    rev: 5.7.0
+    hooks:
+      - id: isort
+        files: '.*'
+        args: [ --profile=black, --project=popmon, --thirdparty histogrammar, --thirdparty pybase64 ]
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: "3.8.4"
+    hooks:
+    -   id: flake8
+        args: [ "--select=E9,F63,F7,F82"]

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,5 @@
-ifeq ($(check),1)
-	CHECK_ARG= --check
-else
-	CHECK_ARG=
-endif
-
 lint:
-	isort $(CHECK_ARG) --profile black --project popmon --thirdparty histogrammar --thirdparty pybase64 .
-	black $(CHECK_ARG) .
+	pre-commit run --all-files
 
 install:
 	pip install -e .

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # POPMON documentation build configuration file for sphinx.
 #

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -83,7 +83,6 @@ The notation 'num', 'low', 'high' gives a fixed range histogram from 'low' to 'h
 number of bins.
 
 
-
 Monitoring rules
 ----------------
 
@@ -195,7 +194,7 @@ Spark usage
 
 .. code-block:: python
 
-  import popmon
+    import popmon
 	from pyspark.sql import SparkSession
 
 	# downloads histogrammar jar files if not already installed, used for histogramming of spark dataframe
@@ -206,3 +205,36 @@ Spark usage
 
 	# generate the report
 	report = spark_df.pm_stability_report(time_axis='timestamp')
+
+
+Spark example on Google Colab
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This snippet contains the instructions for setting up a minimal environment for popmon on Google Colab as a reference.
+
+.. code-block:: console
+
+    !apt-get install openjdk-8-jdk-headless -qq > /dev/null
+    !wget -q https://www-us.apache.org/dist/spark/spark-2.4.7/spark-2.4.7-bin-hadoop2.7.tgz
+    !tar xf spark-2.4.7-bin-hadoop2.7.tgz
+    !wget -P /content/spark-2.4.7-bin-hadoop2.7/jars/ -q https://repo1.maven.org/maven2/org/diana-hep/histogrammar-sparksql_2.11/1.0.4/histogrammar-sparksql_2.11-1.0.4.jar
+    !wget -P /content/spark-2.4.7-bin-hadoop2.7/jars/ -q https://repo1.maven.org/maven2/org/diana-hep/histogrammar_2.11/1.0.4/histogrammar_2.11-1.0.4.jar
+    !pip install -q findspark popmon
+
+Now that spark is installed, restart the runtime.
+
+.. code-block:: python
+
+    import os
+    os.environ["JAVA_HOME"] = "/usr/lib/jvm/java-8-openjdk-amd64"
+    os.environ["SPARK_HOME"] = "/content/spark-2.4.7-bin-hadoop2.7"
+
+    import findspark
+    findspark.init()
+
+    from pyspark.sql import SparkSession
+
+    spark = SparkSession.builder.master("local[*]") \
+      .config("spark.jars", "/content/jars/histogrammar_2.11-1.0.4.jar,/content/jars/histogrammar-sparksql_2.11-1.0.4.jar") \
+      .config("spark.sql.execution.arrow.enabled", "false") \
+      .config("spark.sql.session.timeZone", "GMT") \
+      .getOrCreate()

--- a/make.bat
+++ b/make.bat
@@ -3,13 +3,7 @@
 setlocal enabledelayedexpansion
 
 IF "%1%" == "lint" (
-	IF "%2%" == "check" (
-		SET CHECK_ARG= --check
-	) ELSE (
-		set CHECK_ARG=
-	)
-	isort !CHECK_ARG! --profile black --project popmon --thirdparty histogrammar --thirdparty pybase64 .
-	black !CHECK_ARG! .
+	pre-commit run --all-files
 	GOTO end
 )
 

--- a/popmon/analysis/hist_numpy.py
+++ b/popmon/analysis/hist_numpy.py
@@ -337,9 +337,7 @@ def check_similar_hists(hc_list, check_type=True, assert_type=used_hist_types):
         return False
     dts = [hist.datatype for hist in hist_list]
     if not dts.count(dts[0]) == len(dts):
-        warnings.warn(
-            "Input histograms have inconsistent datatypes: {dts}".format(dts=dts)
-        )
+        warnings.warn(f"Input histograms have inconsistent datatypes: {dts}")
         return False
     # Check generic attributes
     if check_type:

--- a/popmon/hist/filling/histogram_filler_base.py
+++ b/popmon/hist/filling/histogram_filler_base.py
@@ -224,8 +224,9 @@ class HistogramFillerBase(Module):
                     "No obvious time-axes found to choose from. So not used."
                 )
             else:
-                w = f'Found {num} time-axes: {cols_by_type["dt"]}. Set *one* time_axis manually! Now NOT used.'
-                self.logger.warning(w)
+                self.logger.warning(
+                    f'Found {num} time-axes: {cols_by_type["dt"]}. Set *one* time_axis manually! Now NOT used.'
+                )
         else:
             # c) no time axis
             self.time_axis = ""
@@ -275,7 +276,7 @@ class HistogramFillerBase(Module):
     def auto_complete_bin_specs(self, df, cols_by_type):
         """auto complete the bin-specs that have not been provided
 
-        :param df: input dateframe
+        :param df: input dataframe
         :param cols_by_type: dict of columns classified by type
         """
         # auto-determine binning of numerical and time features for which no bin_specs exist
@@ -311,7 +312,7 @@ class HistogramFillerBase(Module):
                 if c in float_cols:
                     q = quantiles_f[c]
                     # by default, n_bins covers range 5-95% quantiles + we add 10%
-                    # basicly this gives a nice plot when plotted
+                    # basically this gives a nice plot when plotted
                     # specs for Bin and Sparselybin histograms
                     if q[1] == q[0]:
                         # in case of highly imbalanced data it can happen that q05=q95. If so use min and max instead.
@@ -354,7 +355,7 @@ class HistogramFillerBase(Module):
         :param str col: column
         """
         if col not in self.get_features(df):
-            raise KeyError('column "{0:s}" not in input dataframe'.format(col))
+            raise KeyError(f'column "{col:s}" not in input dataframe')
         return df[col].dtype
 
     def categorize_features(self, df):
@@ -488,7 +489,7 @@ class HistogramFillerBase(Module):
             else:
                 raise RuntimeError("Do not know how to interpret bin specifications.")
         else:
-            # string and boolians are treated as categories
+            # string and booleans are treated as categories
             hist = hg.Categorize(quantity=quant, value=hist)
 
         return hist

--- a/popmon/hist/filling/make_histograms.py
+++ b/popmon/hist/filling/make_histograms.py
@@ -171,7 +171,7 @@ def get_data_type(df, col):
     :param str col: column
     """
     if col not in df.columns:
-        raise KeyError('Column "{0:s}" not in input dataframe.'.format(col))
+        raise KeyError(f'Column "{col:s}" not in input dataframe.')
     dt = dict(df.dtypes)[col]
 
     if hasattr(dt, "type"):

--- a/popmon/hist/filling/pandas_histogrammar.py
+++ b/popmon/hist/filling/pandas_histogrammar.py
@@ -101,7 +101,7 @@ class PandasHistogrammar(HistogramFillerBase):
         :param df: input (pandas) data frame
         """
         if not isinstance(df, pd.DataFrame):
-            raise TypeError("retrieved object not of type {}".format(pd.DataFrame))
+            raise TypeError(f"retrieved object not of type {pd.DataFrame}")
         if df.shape[0] == 0:
             raise RuntimeError("data is empty")
         return df

--- a/popmon/hist/filling/spark_histogrammar.py
+++ b/popmon/hist/filling/spark_histogrammar.py
@@ -149,7 +149,7 @@ class SparkHistogrammar(HistogramFillerBase):
         :param str col: column
         """
         if col not in df.columns:
-            raise KeyError('Column "{0:s}" not in input dataframe.'.format(col))
+            raise KeyError(f'Column "{col:s}" not in input dataframe.')
         dt = dict(df.dtypes)[col]
         # spark conversions to numpy or python equivalent
         if dt == "string":

--- a/popmon/hist/filling/spark_histogrammar.py
+++ b/popmon/hist/filling/spark_histogrammar.py
@@ -154,7 +154,7 @@ class SparkHistogrammar(HistogramFillerBase):
         # spark conversions to numpy or python equivalent
         if dt == "string":
             dt = "str"
-        elif dt == "timestamp":
+        elif dt in ["timestamp", "date"]:
             dt = np.datetime64
         elif dt == "boolean":
             dt = bool

--- a/popmon/hist/filling/spark_histogrammar.py
+++ b/popmon/hist/filling/spark_histogrammar.py
@@ -184,7 +184,9 @@ class SparkHistogrammar(HistogramFillerBase):
                     col=col, type=self.var_dtype[col]
                 )
             )
-            to_ns = sparkcol(col).cast("float") * 1e9
+
+            # first cast to timestamp (in case column is stored as date)
+            to_ns = sparkcol(col).cast("timestamp").cast("float") * 1e9
             idf = idf.withColumn(col, to_ns)
 
         hg.sparksql.addMethods(idf)
@@ -222,7 +224,7 @@ class SparkHistogrammar(HistogramFillerBase):
         return hist
 
     def fill_histograms(self, idf):
-        """Fill the histogramss
+        """Fill the histograms
 
         :param idf: input data frame used for filling histogram
         """

--- a/popmon/hist/filling/utils.py
+++ b/popmon/hist/filling/utils.py
@@ -34,9 +34,7 @@ def check_column(col, sep=":"):
     if isinstance(col, str):
         col = col.split(sep)
     elif not isinstance(col, list):
-        raise TypeError(
-            'Columns "{}" needs to be a string or list of strings'.format(col)
-        )
+        raise TypeError(f'Columns "{col}" needs to be a string or list of strings')
     return col
 
 
@@ -54,7 +52,7 @@ def check_dtype(dtype):
         if dtype in {np.str_, np.string_, np.object_}:
             dtype = np.dtype(str).type
     except BaseException:
-        raise RuntimeError('unknown assigned datatype "{}"'.format(dtype))
+        raise RuntimeError(f'unknown assigned datatype "{dtype}"')
     return dtype
 
 

--- a/popmon/hist/histogram.py
+++ b/popmon/hist/histogram.py
@@ -163,7 +163,7 @@ def project_split2dhist_on_axis(splitdict, axis="x"):
             "splitdict: {wt}, type should be a dictionary.".format(wt=type(splitdict))
         )
     if axis not in ["x", "y"]:
-        raise ValueError("axis: {axis}, can only be x or y.".format(axis=axis))
+        raise ValueError(f"axis: {axis}, can only be x or y.")
 
     hdict = dict()
 
@@ -217,9 +217,9 @@ class HistogramContainer:
         if convert_time_index and self.is_ts:
             axis_name = pd.Timestamp(axis_name)
         if not short_keys:
-            axis_name = "{name}={binlabel}".format(name=xname, binlabel=axis_name)
+            axis_name = f"{xname}={axis_name}"
             if self.n_dim >= 2:
-                axis_name = "{name}[{slice}]".format(name=yname, slice=axis_name)
+                axis_name = f"{yname}[{axis_name}]"
         return axis_name
 
     def sparse_bin_centers_x(self):

--- a/popmon/pipeline/metrics_pipelines.py
+++ b/popmon/pipeline/metrics_pipelines.py
@@ -106,7 +106,7 @@ def metrics_self_reference(
             apply_funcs=[
                 dict(
                     func=rolling_lr_zscore,
-                    suffix="_trend{w}_zscore".format(w=window),
+                    suffix=f"_trend{window}_zscore",
                     entire=True,
                     window=window,
                     metrics=["mean", "phik", "fraction_true"],
@@ -227,7 +227,7 @@ def metrics_external_reference(
             apply_funcs=[
                 dict(
                     func=rolling_lr_zscore,
-                    suffix="_trend{w}_zscore".format(w=window),
+                    suffix=f"_trend{window}_zscore",
                     entire=True,
                     window=window,
                     metrics=["mean", "phik", "fraction_true"],
@@ -342,7 +342,7 @@ def metrics_rolling_reference(
             apply_funcs=[
                 dict(
                     func=rolling_lr_zscore,
-                    suffix="_trend{w}_zscore".format(w=window),
+                    suffix=f"_trend{window}_zscore",
                     entire=True,
                     window=window,
                     metrics=["mean", "phik", "fraction_true"],
@@ -456,7 +456,7 @@ def metrics_expanding_reference(
             apply_funcs=[
                 dict(
                     func=rolling_lr_zscore,
-                    suffix="_trend{w}_zscore".format(w=window),
+                    suffix=f"_trend{window}_zscore",
                     entire=True,
                     window=window,
                     metrics=["mean", "phik", "fraction_true"],

--- a/popmon/resources.py
+++ b/popmon/resources.py
@@ -28,10 +28,10 @@ from pkg_resources import resource_filename
 import popmon
 
 # data files that are shipped with popmon.
-_DATA = dict(
-    (_.name, _)
+_DATA = {
+    _.name: _
     for _ in pathlib.Path(resource_filename(popmon.__name__, "test_data")).glob("*")
-)
+}
 
 # Tutorial notebooks
 _NOTEBOOK = {

--- a/popmon/stitching/hist_stitcher.py
+++ b/popmon/stitching/hist_stitcher.py
@@ -124,9 +124,7 @@ class HistStitcher(Module):
                 )
             dts = [type(tv) for tv in time_bin_idx]
             if not dts.count(dts[0]) == len(dts):
-                raise TypeError(
-                    "time_bin_idxs have inconsistent datatypes: {dts}".format(dts=dts)
-                )
+                raise TypeError(f"time_bin_idxs have inconsistent datatypes: {dts}")
 
         # basic checks and conversions
         if isinstance(hists_basis, dict) and len(hists_basis) > 0:
@@ -338,9 +336,7 @@ class HistStitcher(Module):
             )
         dts = [type(tv) for tv in time_bin_idx]
         if not dts.count(dts[0]) == len(dts):
-            raise TypeError(
-                "time_bin_idxs have inconsistent datatypes: {dts}".format(dts=dts)
-            )
+            raise TypeError(f"time_bin_idxs have inconsistent datatypes: {dts}")
         if not isinstance(time_bin_idx[0], (str, int, np.integer)):
             raise TypeError("time_bin_idxs should be an (ordered) string or integer.")
 

--- a/popmon/visualization/backend.py
+++ b/popmon/visualization/backend.py
@@ -91,7 +91,7 @@ def set_matplotlib_backend(backend=None, batch=None, silent=True):
                 )
             )
         logger.warning(
-            'Set Matplotlib backend to "{0:s}"; non-interactive backend required, but "{1:s}" requested.'.format(
+            'Set Matplotlib backend to "{:s}"; non-interactive backend required, but "{:s}" requested.'.format(
                 ni_backends[0], backend
             )
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.pytest.ini_options]
-markers =  ["spark", ]
+markers = ["spark"]
 
 [tool.pytest.ini_options.spark_options]
 "spark.executor.id" = "driver"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.pytest.ini_options]
+markers =  ["sparktest",]
+
+[tool.pytest.ini_options.spark_options]
+"spark.executor.id" = "driver"
+"spark.app.name" = "PySparkShell"
+"spark.executor.instances" = 1
+"master" = "local[*]"
+"spark.driver.host" = "192.168.1.78"
+"spark.sql.catalogImplementation" = "in-memory"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.pytest.ini_options]
-markers =  ["sparktest",]
+markers =  ["spark", ]
 
 [tool.pytest.ini_options.spark_options]
 "spark.executor.id" = "driver"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
-flake8>=3.7.8
 pytest>=4.0.2
 pytest-notebook>=0.6.1
 nbconvert~=5.6.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,3 +6,4 @@ jupyter_client>=5.2.3
 ipykernel>=5.1.3
 black>=19.10b0
 isort>=5.0.7
+pre-commit>=2.9.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,6 +4,4 @@ pytest-notebook>=0.6.1
 nbconvert~=5.6.1
 jupyter_client>=5.2.3
 ipykernel>=5.1.3
-black>=19.10b0
-isort>=5.0.7
 pre-commit>=2.9.0

--- a/tests/popmon/base/test_pipeline.py
+++ b/tests/popmon/base/test_pipeline.py
@@ -16,9 +16,7 @@ class LogTransformer(Module):
             datastore, self.input_key, dtype=np.ndarray
         )
         datastore[self.output_key] = np.log(input_array)
-        self.logger.info(
-            "{module_name} is calculated.".format(module_name=self.__class__.__name__)
-        )
+        self.logger.info(f"{self.__class__.__name__} is calculated.")
         return datastore
 
 
@@ -66,9 +64,7 @@ class WeightedSum(Module):
             datastore, self.weight_key, dtype=np.ndarray
         )
         datastore[self.output_key] = np.sum(input_array * weights)
-        self.logger.info(
-            "{module_name} is calculated.".format(module_name=self.__class__.__name__)
-        )
+        self.logger.info(f"{self.__class__.__name__} is calculated.")
         return datastore
 
 

--- a/tests/popmon/conftest.py
+++ b/tests/popmon/conftest.py
@@ -50,7 +50,7 @@ def pytest_configure():
     pytest.test_ref_comparer_df = get_ref_comparer_data()
 
     parent_path = dirname(__file__)
-    TEMPLATE_PATH = "{parent}/hist/resource".format(parent=parent_path)
+    TEMPLATE_PATH = f"{parent_path}/hist/resource"
     CSV_FILE = "test.csv.gz"
 
     with open("{}/{}".format(TEMPLATE_PATH, "age.json")) as f:

--- a/tests/popmon/hist/test_numpy_histogrammar.py
+++ b/tests/popmon/hist/test_numpy_histogrammar.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 import pytest
 

--- a/tests/popmon/hist/test_pandas_histogrammar.py
+++ b/tests/popmon/hist/test_pandas_histogrammar.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 import numpy as np
 import pytest

--- a/tests/popmon/hist/test_spark_histogrammar.py
+++ b/tests/popmon/hist/test_spark_histogrammar.py
@@ -27,7 +27,7 @@ def get_spark():
     spark = (
         SparkSession.builder.master("local")
         .appName("popmon-pytest")
-        .config("spark.jars", "{},{}".format(hist_spark_jar, hist_jar))
+        .config("spark.jars", f"{hist_spark_jar},{hist_jar}")
         .config("spark.sql.execution.arrow.enabled", "false")
         .config("spark.sql.session.timeZone", "GMT")
         .getOrCreate()

--- a/tests/popmon/hist/test_spark_histogrammar.py
+++ b/tests/popmon/hist/test_spark_histogrammar.py
@@ -22,7 +22,6 @@ def get_spark():
     current_path = dirname(abspath(__file__))
 
     hist_spark_jar = join(current_path, "jars/histogrammar-sparksql_2.11-1.0.4.jar")
-
     hist_jar = join(current_path, "jars/histogrammar_2.11-1.0.4.jar")
 
     spark = (
@@ -45,6 +44,7 @@ def spark_co():
     return spark
 
 
+@pytest.mark.spark
 @pytest.mark.skipif(not spark_found, reason="spark not found")
 @pytest.mark.filterwarnings(
     "ignore:createDataFrame attempted Arrow optimization because"
@@ -105,6 +105,7 @@ def test_get_histograms(spark_co):
     #     json.dump(current_hists["transaction"].toJson(), outfile, indent=4)
 
 
+@pytest.mark.spark
 @pytest.mark.skipif(not spark_found, reason="spark not found")
 @pytest.mark.filterwarnings(
     "ignore:createDataFrame attempted Arrow optimization because"
@@ -164,6 +165,7 @@ def test_get_histograms_module(spark_co):
     # assert current_hists['latitude:longitude'].toJson() == pytest.latitude_longitude
 
 
+@pytest.mark.spark
 @pytest.mark.skipif(not spark_found, reason="spark not found")
 @pytest.mark.filterwarnings(
     "ignore:createDataFrame attempted Arrow optimization because"
@@ -209,6 +211,7 @@ def test_get_histograms_timestamp(spark_co):
     assert current_hists["dt"].toJson() == expected
 
 
+@pytest.mark.spark
 @pytest.mark.skipif(not spark_found, reason="spark not found")
 @pytest.mark.filterwarnings(
     "ignore:createDataFrame attempted Arrow optimization because"

--- a/tests/popmon/stitching/test_histogram_stitching.py
+++ b/tests/popmon/stitching/test_histogram_stitching.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 import numpy as np
 import pytest


### PR DESCRIPTION
This PR includes support for the Spark _date_ type (treated as a timestamp).

The remaining changes are:
- Extending the unit tests for this type
- Install Spark on Github Actions to be able to include spark tests in our CI/CD pipeline
- Upgrade linting to use `pre-commit` (including pyupgrade for python3.6 syntax upgrades)
- Document how to run popmon using spark on Google Colab (minimal example from scratch)
