### PR TITLE
fix: turn off minor_ticks for compatibility with matplotlib >= 3.4.0

### DIFF
--- a/popmon/visualization/utils.py
+++ b/popmon/visualization/utils.py
@@ -34,7 +34,7 @@ from popmon.resources import templates_env
 NUM_NS_DAY = 24 * 3600 * int(1e9)
 
 logger = logging.getLogger()
-mpl_style(dark=False)
+mpl_style(dark=False, minor_ticks=False)
 
 
 def plt_to_str(format="png"):


### PR DESCRIPTION
turn off minor_ticks for compatibility with matplotlib >= 3.4.0 (issue reported to ing_theme_matplotlib)

(thanks @mgorsk1)