### PR TITLE
ci: flake8 comprehensions + updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.4b0
     hooks:
     - id: black
 -   repo: https://github.com/pycqa/isort
@@ -8,14 +8,16 @@ repos:
     hooks:
       - id: isort
         files: '.*'
-        args: [ --profile=black, --project=popmon, --thirdparty histogrammar, --thirdparty pybase64 ]
+        args: [ --profile=black, --project=popmon ]
 -   repo: https://github.com/PyCQA/flake8
     rev: "3.9.1"
     hooks:
     -   id: flake8
-        args: [ "--select=E9,F63,F7,F82"]
+        additional_dependencies:
+            - flake8-comprehensions
+        args: [ "--select=E9,F63,F7,F82,C4"]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.12.0
+    rev: v2.13.0
     hooks:
     -   id: pyupgrade
         args: ['--py36-plus','--exit-zero-even-if-changed']

--- a/tests/popmon/alerting/test_apply_tl_bounds.py
+++ b/tests/popmon/alerting/test_apply_tl_bounds.py
@@ -193,7 +193,7 @@ def test_apply_static_traffic_light_bounds():
 
 
 def test_rolling_window_funcs():
-    datastore = dict(to_profile={"asc_numbers": get_test_data()})
+    datastore = {"to_profile": {"asc_numbers": get_test_data()}}
 
     m = ApplyFunc(
         apply_to_key="to_profile", features=["asc_numbers"], metrics=["a", "b"]

--- a/tests/popmon/alerting/test_integration.py
+++ b/tests/popmon/alerting/test_integration.py
@@ -79,7 +79,7 @@ def test_traffic_light_summary():
 
     tls = ApplyFunc(
         apply_to_key="output_data",
-        apply_funcs=[dict(func=traffic_light_summary, axis=1, suffix="")],
+        apply_funcs=[{"func": traffic_light_summary, "axis": 1, "suffix": ""}],
         assign_to_key="alerts",
     )
 
@@ -124,7 +124,7 @@ def test_traffic_light_summary_combination():
 
     tls = ApplyFunc(
         apply_to_key="output_data",
-        apply_funcs=[dict(func=traffic_light_summary, axis=1, suffix="")],
+        apply_funcs=[{"func": traffic_light_summary, "axis": 1, "suffix": ""}],
         assign_to_key="alerts",
     )
 

--- a/tests/popmon/analysis/comparison/test_hist_comparer.py
+++ b/tests/popmon/analysis/comparison/test_hist_comparer.py
@@ -39,26 +39,26 @@ def test_hist_compare():
             ApplyFunc(
                 apply_to_key="output_hist",
                 apply_funcs=[
-                    dict(
-                        func=expanding_hist,
-                        shift=1,
-                        suffix="sum",
-                        entire=True,
-                        hist_name="histogram",
-                    )
+                    {
+                        "func": expanding_hist,
+                        "shift": 1,
+                        "suffix": "sum",
+                        "entire": True,
+                        "hist_name": "histogram",
+                    }
                 ],
             ),
             ApplyFunc(
                 apply_to_key="output_hist",
                 assign_to_key="comparison",
                 apply_funcs=[
-                    dict(
-                        func=hist_compare,
-                        hist_name1="histogram",
-                        hist_name2="histogram_sum",
-                        suffix="",
-                        axis=1,
-                    )
+                    {
+                        "func": hist_compare,
+                        "hist_name1": "histogram",
+                        "hist_name2": "histogram_sum",
+                        "suffix": "",
+                        "axis": 1,
+                    }
                 ],
             ),
         ]

--- a/tests/popmon/analysis/test_functions.py
+++ b/tests/popmon/analysis/test_functions.py
@@ -63,13 +63,13 @@ def test_expanding_hist():
             ApplyFunc(
                 apply_to_key="output_hist",
                 apply_funcs=[
-                    dict(
-                        func=expanding_hist,
-                        shift=1,
-                        suffix="sum",
-                        entire=True,
-                        hist_name="histogram",
-                    )
+                    {
+                        "func": expanding_hist,
+                        "shift": 1,
+                        "suffix": "sum",
+                        "entire": True,
+                        "hist_name": "histogram",
+                    }
                 ],
             ),
         ]
@@ -222,14 +222,14 @@ def test_rolling_hist():
             ApplyFunc(
                 apply_to_key="output_hist",
                 apply_funcs=[
-                    dict(
-                        func=rolling_hist,
-                        window=5,
-                        shift=1,
-                        suffix="sum",
-                        entire=True,
-                        hist_name="histogram",
-                    )
+                    {
+                        "func": rolling_hist,
+                        "window": 5,
+                        "shift": 1,
+                        "suffix": "sum",
+                        "entire": True,
+                        "hist_name": "histogram",
+                    }
                 ],
             ),
         ]
@@ -333,7 +333,7 @@ def test_normalized_hist_mean_cov():
             ApplyFunc(
                 apply_to_key="output_hist",
                 assign_to_key="output_hist",
-                apply_funcs=[dict(func=normalized_hist_mean_cov, suffix="")],
+                apply_funcs=[{"func": normalized_hist_mean_cov, "suffix": ""}],
             ),
         ]
     )
@@ -394,14 +394,14 @@ def test_roll_norm_hist_mean_cov():
             ApplyFunc(
                 apply_to_key="output_hist",
                 apply_funcs=[
-                    dict(
-                        func=roll_norm_hist_mean_cov,
-                        hist_name="histogram",
-                        window=5,
-                        shift=1,
-                        suffix="",
-                        entire=True,
-                    )
+                    {
+                        "func": roll_norm_hist_mean_cov,
+                        "hist_name": "histogram",
+                        "window": 5,
+                        "shift": 1,
+                        "suffix": "",
+                        "entire": True,
+                    }
                 ],
             ),
         ]
@@ -514,13 +514,13 @@ def test_expand_norm_hist_mean_cov():
             ApplyFunc(
                 apply_to_key="output_hist",
                 apply_funcs=[
-                    dict(
-                        func=expand_norm_hist_mean_cov,
-                        hist_name="histogram",
-                        shift=1,
-                        suffix="",
-                        entire=True,
-                    )
+                    {
+                        "func": expand_norm_hist_mean_cov,
+                        "hist_name": "histogram",
+                        "shift": 1,
+                        "suffix": "",
+                        "entire": True,
+                    }
                 ],
             ),
         ]
@@ -636,19 +636,19 @@ def test_chi_squared1():
             ApplyFunc(
                 apply_to_key="output_hist",
                 apply_funcs=[
-                    dict(
-                        func=roll_norm_hist_mean_cov,
-                        hist_name="histogram",
-                        window=5,
-                        shift=1,
-                        suffix="",
-                        entire=True,
-                    )
+                    {
+                        "func": roll_norm_hist_mean_cov,
+                        "hist_name": "histogram",
+                        "window": 5,
+                        "shift": 1,
+                        "suffix": "",
+                        "entire": True,
+                    }
                 ],
             ),
             ApplyFunc(
                 apply_to_key="output_hist",
-                apply_funcs=[dict(func=relative_chi_squared, suffix="", axis=1)],
+                apply_funcs=[{"func": relative_chi_squared, "suffix": "", "axis": 1}],
             ),
         ]
     )
@@ -698,18 +698,18 @@ def test_chi_squared2():
             ApplyFunc(
                 apply_to_key="output_hist",
                 apply_funcs=[
-                    dict(
-                        func=expand_norm_hist_mean_cov,
-                        hist_name="histogram",
-                        shift=1,
-                        suffix="",
-                        entire=True,
-                    )
+                    {
+                        "func": expand_norm_hist_mean_cov,
+                        "hist_name": "histogram",
+                        "shift": 1,
+                        "suffix": "",
+                        "entire": True,
+                    }
                 ],
             ),
             ApplyFunc(
                 apply_to_key="output_hist",
-                apply_funcs=[dict(func=relative_chi_squared, suffix="", axis=1)],
+                apply_funcs=[{"func": relative_chi_squared, "suffix": "", "axis": 1}],
             ),
         ]
     )


### PR DESCRIPTION
- bump black, pyupgrade
- flake8 comprehensions (incentive to not use dict constructors)
- remove isort args that are no longer needed