### PR TITLE
Distinct incorrect result (constant)

### DIFF
--- a/popmon/analysis/profiling/hist_profiler.py
+++ b/popmon/analysis/profiling/hist_profiler.py
@@ -118,7 +118,7 @@ class HistProfiler(Module):
             "filled": bin_counts.sum(),
             "overflow": hist.overflow.entries if hasattr(hist, "overflow") else 0,
             "underflow": (hist.underflow.entries if hasattr(hist, "underflow") else 0),
-            "distinct": len(np.unique(bin_labels)),
+            "distinct": len(np.unique(bin_labels[bin_counts > 0])),
         }
 
         if hasattr(hist, "nanflow"):


### PR DESCRIPTION
The distinct profile included empty bins. This resulted in reporting the constant total distinct bin labels, instead of the distinct number per bin.