### PR TITLE
fix(report): text contrast and consistent yellow traffic light

### DIFF
--- a/popmon/visualization/templates/assets/css/custom-style.css
+++ b/popmon/visualization/templates/assets/css/custom-style.css
@@ -73,7 +73,7 @@ table.overview td.cell-yellow{
     background: rgba(255, 200, 0, 1.0);
 }
 table.overview td.cell-red{
-    background: red;
+    background: rgba(255, 0, 0, 1.0);
 }
 table.overview tfoot td {
     padding-top: 5px;
@@ -105,5 +105,5 @@ table.overview tfoot td span{
     background-color: rgba(255, 200, 0, 1.0);
 }
 .red{
-    background-color: red;
+    background-color: rgba(255, 0, 0, 1.0);
 }

--- a/popmon/visualization/templates/assets/css/custom-style.css
+++ b/popmon/visualization/templates/assets/css/custom-style.css
@@ -70,7 +70,7 @@ table.overview td.cell-green{
     background: green;
 }
 table.overview td.cell-yellow{
-    background: yellow;
+    background: rgba(255, 200, 0, 1.0);
 }
 table.overview td.cell-red{
     background: red;
@@ -102,7 +102,7 @@ table.overview tfoot td span{
     background-color: green;
 }
 .yellow{
-    background-color: orange;
+    background-color: rgba(255, 200, 0, 1.0);
 }
 .red{
     background-color: red;

--- a/popmon/visualization/templates/table.html
+++ b/popmon/visualization/templates/table.html
@@ -20,6 +20,10 @@
             {% with rgba, value = data[metric][label] %}
             <td class="cell" style="background-color: rgba({{ ', '.join(rgba) }})">{{ value }}</td>
             {% endwith %}
+        {% elif data[metric][label] | length == 3 %}
+            {% with text_color, rgba, value = data[metric][label] %}
+            <td class="cell" style="color: {{ text_color }}; background-color: rgba({{ ', '.join(rgba) }})">{{ value }}</td>
+            {% endwith %}
         {% endif %}
     {% endfor %}
 </tr>

--- a/popmon/visualization/utils.py
+++ b/popmon/visualization/utils.py
@@ -125,18 +125,20 @@ def plot_bars_b64(data, labels=None, bounds=None, ylim=False, skip_empty=True):
             y_max += spread
             y_min -= spread
 
+            yellow = (1.0, 200 / 222, 0.0)
+
             if not isinstance(max_r, (list, tuple)):
                 ax.axhline(y=max_r, xmin=0, xmax=1, color="r")
             else:
                 ax.plot(index, max_r, color="r")
             if not isinstance(max_r, (list, tuple)):
-                ax.axhline(y=max_y, xmin=0, xmax=1, color="y")
+                ax.axhline(y=max_y, xmin=0, xmax=1, color=yellow)
             else:
-                ax.plot(index, max_y, color="y")
+                ax.plot(index, max_y, color=yellow)
             if not isinstance(max_r, (list, tuple)):
-                ax.axhline(y=min_y, xmin=0, xmax=1, color="y")
+                ax.axhline(y=min_y, xmin=0, xmax=1, color=yellow)
             else:
-                ax.plot(index, min_y, color="y")
+                ax.plot(index, min_y, color=yellow)
             if not isinstance(max_r, (list, tuple)):
                 ax.axhline(y=min_r, xmin=0, xmax=1, color="r")
             else:
@@ -188,13 +190,14 @@ def render_alert_aggregate_table(feature, data, metrics: List[str], labels: List
         for c2, label in enumerate(labels):
             a = data[c1][c2] / row_max if row_max and row_max != 0 else 0
             if metric.endswith("green"):
-                rgba = (0, 128, 0, a)
+                background_rgba = (0, 128, 0, a)
             elif metric.endswith("yellow"):
-                rgba = (255, 255, 0, a)
+                background_rgba = (255, 200, 0, a)
             else:
-                rgba = (255, 0, 0, a)
-            rgba = (str(v) for v in rgba)
-            colors[metric][label] = (rgba, data[c1][c2])
+                background_rgba = (255, 0, 0, a)
+            background_rgba = (str(v) for v in background_rgba)
+            text_color = "white" if a > 0.5 else "black"
+            colors[metric][label] = (text_color, background_rgba, data[c1][c2])
 
     return templates_env(
         "table.html",

--- a/popmon/visualization/utils.py
+++ b/popmon/visualization/utils.py
@@ -125,12 +125,13 @@ def plot_bars_b64(data, labels=None, bounds=None, ylim=False, skip_empty=True):
             y_max += spread
             y_min -= spread
 
-            yellow = (1.0, 200 / 222, 0.0)
+            yellow = (1.0, 200 / 255, 0.0)
+            red = (1.0, 0.0, 0.0)
 
             if not isinstance(max_r, (list, tuple)):
-                ax.axhline(y=max_r, xmin=0, xmax=1, color="r")
+                ax.axhline(y=max_r, xmin=0, xmax=1, color=red)
             else:
-                ax.plot(index, max_r, color="r")
+                ax.plot(index, max_r, color=red)
             if not isinstance(max_r, (list, tuple)):
                 ax.axhline(y=max_y, xmin=0, xmax=1, color=yellow)
             else:
@@ -140,9 +141,9 @@ def plot_bars_b64(data, labels=None, bounds=None, ylim=False, skip_empty=True):
             else:
                 ax.plot(index, min_y, color=yellow)
             if not isinstance(max_r, (list, tuple)):
-                ax.axhline(y=min_r, xmin=0, xmax=1, color="r")
+                ax.axhline(y=min_r, xmin=0, xmax=1, color=red)
             else:
-                ax.plot(index, min_r, color="r")
+                ax.plot(index, min_r, color=red)
             if y_max > y_min:
                 ax.set_ylim(y_min, y_max)
         elif ylim:


### PR DESCRIPTION
- Fix contrast in text of alert section
- Use consistent yellow/orange throughout the report for traffic lights