### PR TITLE
Protection against (extreme) outliers in sparse histograms

### DIFF
--- a/popmon/analysis/comparison/hist_comparer.py
+++ b/popmon/analysis/comparison/hist_comparer.py
@@ -34,7 +34,6 @@ from ...analysis.functions import (
 )
 from ...analysis.hist_numpy import (
     check_similar_hists,
-    get_consistent_numpy_1dhists,
     get_consistent_numpy_entries,
     get_consistent_numpy_ndgrids,
 )
@@ -95,9 +94,8 @@ def hist_compare(row, hist_name1="", hist_name2="", max_res_bound=7.0):
     # compare
     if hist1.n_dim == 1:
         if is_numeric(hist1):
-            numpy_1dhists = get_consistent_numpy_1dhists([hist1, hist2])
-            entries_list = [nphist[0] for nphist in numpy_1dhists]
             # KS-test only properly defined for (ordered) 1D interval variables
+            entries_list = get_consistent_numpy_entries([hist1, hist2])
             ks_testscore = ks_test(*entries_list)
             x["ks"] = ks_testscore
             ks_pvalue = ks_prob(ks_testscore)

--- a/popmon/analysis/functions.py
+++ b/popmon/analysis/functions.py
@@ -343,12 +343,7 @@ def hist_sum(x, hist_name=""):
     if not similar:
         return pd.Series(o)
 
-    # MB FIX: h_sum not initialized correctly in a sum by histogrammar for sparselybin (origin); below it is.
-    # h_sum = np.sum([hist for hist in hist_list])
-
-    h_sum = hist_list[0].zero()
-    for hist in hist_list:
-        h_sum += hist
+    h_sum = np.sum(hist_list)
     o[hist_name] = h_sum
     return pd.Series(o)
 

--- a/popmon/analysis/profiling/hist_profiler.py
+++ b/popmon/analysis/profiling/hist_profiler.py
@@ -207,8 +207,8 @@ class HistProfiler(Module):
         is_num = is_numeric(hist)
         is_ts = is_timestamp(hist) or name in self.var_timestamp
 
-        bin_labels = np.array(get_bin_centers(hist)[0])
-        bin_counts = np.array([v.entries for v in get_bin_centers(hist)[1]])
+        bin_labels, values = get_bin_centers(hist)
+        bin_counts = np.array([v.entries for v in values])
 
         if len(bin_counts) == 0:
             self.logger.warning(f'Histogram "{name}" is empty; skipping.')

--- a/popmon/hist/hist_utils.py
+++ b/popmon/hist/hist_utils.py
@@ -220,13 +220,15 @@ def is_numeric(hist):
 
 def sparse_bin_centers_x(hist):
     """Get x-axis bin centers of sparse histogram"""
-    keys = sorted(hist.bins.keys())
+    # note: want sorted keys for plotting
+    keys = np.array(sorted(hist.bins.keys()))
     if hist.minBin is None or hist.maxBin is None:
         # number of bins is set to 1.
         centers = np.array([hist.origin + 0.5 * hist.binWidth])
     else:
-        centers = np.array([hist.origin + (i + 0.5) * hist.binWidth for i in keys])
-
+        # default for filled histogram
+        centers = hist.origin + (keys + 0.5) * hist.binWidth
+    # note: so values is also sorted
     values = [hist.bins[key] for key in keys]
     return centers, values
 

--- a/popmon/visualization/section_generator.py
+++ b/popmon/visualization/section_generator.py
@@ -132,7 +132,7 @@ class SectionGenerator(Module):
                 inplace=True,
                 errors="ignore",
             )
-            dates = [short_date(str(date)) for date in df.index.tolist()]
+            dates = np.array([short_date(str(date)) for date in df.index.tolist()])
 
             metrics = filter_metrics(
                 df.columns, self.ignore_stat_endswith, self.show_stats
@@ -143,7 +143,7 @@ class SectionGenerator(Module):
                     feature,
                     metric,
                     dates,
-                    df[metric],
+                    df[metric].values,
                     static_bounds,
                     fdbounds,
                     self.prefix,
@@ -201,13 +201,14 @@ def _plot_metric(
     )
     # choose dynamic bounds if present
     bounds = dbounds if len(dbounds) > 0 else sbounds
+
     # prune dates and values
     dates = _prune(dates, last_n, skip_first_n, skip_last_n)
     values = _prune(values, last_n, skip_first_n, skip_last_n)
 
     # make plot. note: slow!
     plot = plot_bars_b64(
-        data=np.array(values),
+        data=values,
         labels=dates,
         ylim=True,
         bounds=bounds,

--- a/popmon/visualization/utils.py
+++ b/popmon/visualization/utils.py
@@ -78,7 +78,7 @@ def plot_bars_b64(data, labels=None, bounds=None, ylim=False, skip_empty=True):
     """
     # basic checks first
     n = data.size  # number of bins
-    if labels and len(labels) != n:
+    if labels is not None and len(labels) != n:
         raise ValueError("shape mismatch: x-axis labels do not match the data shape")
 
     # skip plot generation for empty datasets
@@ -97,7 +97,7 @@ def plot_bars_b64(data, labels=None, bounds=None, ylim=False, skip_empty=True):
     width = (index[1] - index[0]) * 0.9 if n >= 2 else 1.0
     ax.bar(index, data, width=width, align="center")
 
-    if labels:
+    if labels is not None:
         ax.set_xticks(index)
         ax.set_xticklabels(labels, fontdict={"rotation": "vertical"})
         granularity = math.ceil(len(labels) / 50)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.18.0
 pandas>=0.25.1
 scipy>=1.5.2
-histogrammar>=1.0.27
+histogrammar>=1.0.28
 phik
 jinja2
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 with open("requirements.txt") as f:
     REQUIREMENTS = f.read().splitlines()

--- a/tests/popmon/analysis/test_functions.py
+++ b/tests/popmon/analysis/test_functions.py
@@ -425,67 +425,6 @@ def test_roll_norm_hist_mean_cov():
         [
             0.8,
             0.1,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
             0.1,
         ]
     )
@@ -545,66 +484,9 @@ def test_expand_norm_hist_mean_cov():
             0.56666667,
             0.03333333,
             0.03333333,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
             0.06666667,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
             0.06666667,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
             0.06666667,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
             0.03333333,
             0.06666667,
             0.06666667,
@@ -665,15 +547,15 @@ def test_chi_squared1():
         assert f in datastore["output_hist"]
 
     df = datastore["output_hist"]["A_score"]
-    np.testing.assert_almost_equal(df["chi2"][6], 4.25)
+    np.testing.assert_almost_equal(df["chi2"].values[6], 4.25)
     df = datastore["output_hist"]["A_score:num_employees"]
-    np.testing.assert_almost_equal(df["chi2"][-2], 2.1333333333333315)
+    np.testing.assert_almost_equal(df["chi2"].values[-2], 2.1333333333333315)
     df = datastore["output_hist"]["bankrupt"]
-    np.testing.assert_almost_equal(df["chi2"][6], 0.40000000000000024)
+    np.testing.assert_almost_equal(df["chi2"].values[6], 0.40000000000000024)
     df = datastore["output_hist"]["country"]
-    np.testing.assert_almost_equal(df["chi2"][5], 0.8999999999999994)
+    np.testing.assert_almost_equal(df["chi2"].values[5], 0.8999999999999994)
     df = datastore["output_hist"]["num_employees"]
-    np.testing.assert_almost_equal(df["chi2"][5], 0.849999999999999)
+    np.testing.assert_almost_equal(df["chi2"].values[5], 0.849999999999999)
 
 
 @pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide")
@@ -726,15 +608,15 @@ def test_chi_squared2():
         assert f in datastore["output_hist"]
 
     df = datastore["output_hist"]["A_score"]
-    np.testing.assert_almost_equal(df["chi2"][-1], 9.891821919006366)
+    np.testing.assert_almost_equal(df["chi2"].values[-1], 9.891821919006366)
     df = datastore["output_hist"]["A_score:num_employees"]
-    np.testing.assert_almost_equal(df["chi2"][-2], 3.217532467532462)
+    np.testing.assert_almost_equal(df["chi2"].values[-2], 3.217532467532462)
     df = datastore["output_hist"]["bankrupt"]
-    np.testing.assert_almost_equal(df["chi2"][-1], 0.23767605633802757)
+    np.testing.assert_almost_equal(df["chi2"].values[-1], 0.23767605633802757)
     df = datastore["output_hist"]["country"]
-    np.testing.assert_almost_equal(df["chi2"][-1], 1.3717532467532458)
+    np.testing.assert_almost_equal(df["chi2"].values[-1], 1.3717532467532458)
     df = datastore["output_hist"]["num_employees"]
-    np.testing.assert_almost_equal(df["chi2"][-1], 1.1858766233766194)
+    np.testing.assert_almost_equal(df["chi2"].values[-1], 1.1858766233766194)
 
 
 def test_chi_ReferenceNormHistComparer():
@@ -775,7 +657,7 @@ def test_chi_ReferenceNormHistComparer():
         assert f in datastore["comparisons"]
 
     df = datastore["comparisons"]["A_score"]
-    np.testing.assert_almost_equal(df["chi2"][0], 2.2884111855886022)
+    np.testing.assert_almost_equal(df["chi2"].values[0], 2.2884111855886022)
 
 
 def test_chi_ExpandingNormHistComparer():
@@ -812,7 +694,7 @@ def test_chi_ExpandingNormHistComparer():
         assert f in datastore["comparisons"]
 
     df = datastore["comparisons"]["A_score"]
-    np.testing.assert_almost_equal(df["chi2"][-1], 9.891821919006366)
+    np.testing.assert_almost_equal(df["chi2"].values[-1], 9.891821919006366)
 
 
 def test_chi_RollingNormHistComparer():
@@ -851,4 +733,4 @@ def test_chi_RollingNormHistComparer():
         assert f in datastore["comparisons"]
 
     df = datastore["comparisons"]["A_score"]
-    np.testing.assert_almost_equal(df["chi2"][-1], 37.61910112359518)
+    np.testing.assert_almost_equal(df["chi2"].values[-1], 37.61910112359518)


### PR DESCRIPTION
- Protection against outliers in sparse histograms
  o Protect against extreme outliers in sparse histograms by avoiding the use of its dense representation where possible.
- Performance speedup in histogram summation
  o Replace for loop with np.sum
- Working analysis function unit tests
  o black histogram_section code
  o update of test_report_generator
  o section_generator now passes np arrays to plot_bars_b64, no longer pd.Series.
- Bump up versions of histogrammar and popmon