### PR TITLE
histogrammar number of bins fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.18.0
 pandas>=0.25.1
 scipy>=1.5.2
-histogrammar>=1.0.28
+histogrammar>=1.0.29
 phik
 jinja2
 tqdm


### PR DESCRIPTION
Fixed rounding error in num_bins call of Bin histogram, which is needed for plotting of cropped histograms 
in histogram section of the report.