### PR TITLE
Add section on external profiles to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Population Shift Monitoring
 `popmon` works with both **pandas** and **spark datasets**.
 
 `popmon` creates histograms of features binned in time-slices,
-and compares the stability of the `profiles <https://popmon.readthedocs.io/en/latest/profiles.html>`_ and distributions of
+and compares the stability of the profiles_ and distributions of
 those histograms using `statistical tests <https://popmon.readthedocs.io/en/latest/comparisons.html>`_, both over time and with respect to a reference.
 It works with numerical, ordinal, categorical features, and the histograms can be higher-dimensional, e.g. it can also track correlations between any two features.
 `popmon` can **automatically flag** and alert on **changes observed over time**, such
@@ -199,7 +199,21 @@ Contributions of additional or improved integrations are welcome!
     :height: 120
     :target: https://github.com/elastic/kibana
 
+Profile integrations
+--------------------
 
+External libraries or custom functionality can be easily added using Profiles_.
+If you developed a custom profile that could be generically used, then please considering contributing it to the package.
+
+Popmon currently integrates:
+
+* `Diptest <https://github.com/RUrlus/diptest>`_
+
+A Python/C++ implementation of Hartigan & Hartigan's dip test for unimodality.
+The dip test tests for multimodality in a sample by taking the maximum difference, over all sample points, between the empirical distribution function, and the unimodal distribution function that minimizes that maximum difference.
+Other than unimodality, it makes no further assumptions about the form of the null distribution.
+
+To enable this extension install diptest using ``pip install diptest`` or ``pip install popmon[diptest]``.
 
 Resources
 =========
@@ -298,3 +312,5 @@ Copyright ING WBAA. `popmon` is completely free, open-source and licensed under 
 .. |downloads| image:: https://pepy.tech/badge/popmon
     :alt: PyPi downloads
     :target: https://pepy.tech/project/popmon
+
+.. _profiles: https://popmon.readthedocs.io/en/latest/profiles.html

--- a/docs/source/profiles.rst
+++ b/docs/source/profiles.rst
@@ -8,30 +8,30 @@ Available profiles
 ------------------
 The following metrics are implemented:
 
-Any dimension
+**Any dimension**
 
-- count
+* count
 
-1D histogram, all types:
+**1D histogram, all types:**
 
-- filled
-- underflow, overflow
-- nan
+* filled
+* underflow, overflow
+* nan
 
-1D histogram, numeric:
+**1D histogram, numeric:**
 
-- mean
-- 1%, 5%, 16%, 50% (median), 84%, 95%, 99% percentiles
-- std
-- min, max
+* mean
+* 1%, 5%, 16%, 50% (median), 84%, 95%, 99% percentiles
+* std
+* min, max
 
-1D histogram, categorical
+**1D histogram, categorical**
 
-- fraction of true
+* fraction of true
 
-2D histogram:
+**2D histogram:**
 
-- phik
+* phik
 
 Profile extensions
 ------------------
@@ -79,8 +79,7 @@ Variations:
         result1, result2 = your_logic(hist)
         return result1, result2
 
-- A profile may work on the histogram, or on the value counts/labels (also for efficiency).
-This occurs when the ``htype`` parameter is passed (1D only)
+- A profile may work on the histogram, or on the value counts/labels (also for efficiency). This occurs when the ``htype`` parameter is passed (1D only)
 
 .. code-block:: python
 


### PR DESCRIPTION
This PR adds a small section to the readme with some details on external profiles and diptest.

## Enhancements

* bdf71133ef5d63211e9caa7f30a627da8afea795 -- add section on external profiles

## Changes

* 9a706e3220b573b57b77407a0bf8a9df54be1312 -- make bulleted list of profiles easier to read
