### PR TITLE
fix: restrict plotly to version smaller than 6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "phik",
     "jinja2",
     "tqdm",
-    "plotly>=5.8.0",
+    "plotly<6",
     "joblib>=0.14.0",
     "htmlmin",
     "pydantic>=2",


### PR DESCRIPTION
For >6 plots are rotated in report. To be investigated.